### PR TITLE
feat: add MCP server for AI agent access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,31 @@ SESSION_SECRET=change-this-to-a-random-string-in-production
 
 # Optional: Node environment
 NODE_ENV=development
+
+# ====================================
+# MCP Server Configuration
+# ====================================
+# Enable MCP server for AI agent access (Claude, Copilot, etc.)
+
+# Enable/disable MCP server (default: false)
+MCP_ENABLED=false
+
+# MCP server port (default: 3002)
+MCP_PORT=3002
+
+# MCP server host (default: 0.0.0.0)
+# Use 127.0.0.1 to restrict to localhost only
+MCP_HOST=0.0.0.0
+
+# API key for MCP authentication (required for production)
+# Clients must provide this key in Authorization header
+MCP_API_KEY=your-mcp-api-key-here
+
+# Session timeout in milliseconds (default: 24 hours)
+MCP_SESSION_TTL_MS=86400000
+
+# Maximum sessions per API key (default: 100)
+MCP_MAX_SESSIONS=100
+
+# Enable debug logging (default: false)
+MCP_DEBUG=false

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,2 @@
+# Ignore example API keys in MCP documentation
+server/src/mcp/README.md:curl-auth-header:140

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ codex/
 - [Installation](#-installation)
 - [Usage](#-usage)
 - [Project Structure](#-project-structure)
+- [MCP Server (AI Agent Access)](#-mcp-server-ai-agent-access)
 - [API Documentation](#-api-documentation)
 - [Testing](#-testing)
 - [Development](#-development)
@@ -534,7 +535,74 @@ server {
 
 **Why?** In production mode, session cookies use `secure: auto`, which requires HTTPS. Direct HTTP access with a password set will fail because the browser won't send the secure cookie. The reverse proxy provides HTTPS termination while communicating with Codex via HTTP internally.
 
-## �📡 API Documentation
+## 🤖 MCP Server (AI Agent Access)
+
+Codex includes a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that allows AI agents like Claude, GitHub Copilot, and other MCP-compatible clients to interact with your documentation.
+
+### Quick Setup
+
+1. **Enable the MCP server** by setting environment variables:
+   ```bash
+   export MCP_ENABLED=true
+   export MCP_API_KEY=your-secure-api-key
+   ```
+
+2. **Start the server** (runs alongside the main app):
+   ```bash
+   npm run dev:mcp -w server  # Development with hot reload
+   ```
+
+3. **Connect your MCP client** to `http://localhost:3002/mcp`
+
+### Available Tools
+
+The MCP server exposes 12 tools for AI agents:
+
+| Tool | Description |
+|------|-------------|
+| `search_pages` | Search documentation by query |
+| `get_page` | Read a page's content |
+| `create_page` | Create a new page |
+| `update_page` | Update an existing page |
+| `delete_page` | Delete a page |
+| `rename_page` | Rename a page |
+| `move_page` | Move a page to another folder |
+| `list_folders` | Get folder hierarchy |
+| `list_pages` | List pages in a folder |
+| `create_folder` | Create a new folder |
+| `delete_folder` | Delete an empty folder |
+| `rename_folder` | Rename a folder |
+
+### Client Configuration
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "codex": {
+      "url": "http://localhost:3002/mcp",
+      "headers": { "Authorization": "Bearer your-api-key" }
+    }
+  }
+}
+```
+
+**VS Code / GitHub Copilot** (settings or `mcp.json`):
+```json
+{
+  "servers": {
+    "codex": {
+      "type": "http",
+      "url": "http://localhost:3002/mcp",
+      "headers": { "Authorization": "Bearer your-api-key" }
+    }
+  }
+}
+```
+
+For full documentation, see [server/src/mcp/README.md](server/src/mcp/README.md).
+
+## 📡 API Documentation
 
 The REST API is available at `http://localhost:3001/api`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1551,6 +1551,18 @@
         }
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2609,6 +2621,82 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.25.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.3.tgz",
+      "integrity": "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -4348,7 +4436,6 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -4426,6 +4513,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -4832,7 +4958,6 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
@@ -5575,7 +5700,6 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -5898,7 +6022,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6907,6 +7030,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -6981,7 +7125,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7092,7 +7235,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -7115,6 +7257,22 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
       "version": "5.3.3",
@@ -7205,7 +7363,6 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -7374,7 +7531,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -7984,6 +8140,16 @@
       "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
       "license": "CC0-1.0"
     },
+    "node_modules/hono": {
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -8107,7 +8273,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -8405,8 +8570,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -8444,7 +8608,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -10224,6 +10387,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10324,6 +10496,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -10992,7 +11170,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -11181,7 +11358,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -11800,7 +11976,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11810,7 +11985,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -12071,7 +12245,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12410,7 +12583,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12452,7 +12624,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
       "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -12526,6 +12697,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -12783,7 +12963,6 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -13183,7 +13362,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13353,7 +13531,6 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -13438,7 +13615,6 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -13465,7 +13641,6 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -13496,7 +13671,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -13509,7 +13683,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14712,7 +14885,6 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -15302,7 +15474,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -15687,6 +15858,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -15701,9 +15890,11 @@
       "name": "codex-server",
       "version": "1.0.0",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.3",
         "cors": "^2.8.6",
         "express": "^4.18.2",
-        "multer": "^2.0.2"
+        "multer": "^2.0.2",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",

--- a/server/package.json
+++ b/server/package.json
@@ -5,15 +5,20 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "dev:mcp": "MCP_ENABLED=true ts-node-dev --respawn --transpile-only src/index.ts",
+    "mcp": "node --loader ts-node/esm src/mcp/standalone.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "start:mcp": "MCP_ENABLED=true node dist/index.js",
     "test": "jest",
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.25.3",
     "cors": "^2.8.6",
     "express": "^4.18.2",
-    "multer": "^2.0.2"
+    "multer": "^2.0.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -242,11 +242,26 @@ if (process.env.NODE_ENV === "production") {
   });
 }
 
+// Start MCP server if enabled
+async function startMcpServerIfEnabled() {
+  if (process.env.MCP_ENABLED === "true") {
+    try {
+      const { startMcpServer } = await import("./mcp/server");
+      startMcpServer();
+    } catch (error) {
+      console.error("Failed to start MCP server:", error);
+    }
+  }
+}
+
 // Start server
 if (require.main === module) {
   app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);
   });
+
+  // Start MCP server alongside main API
+  startMcpServerIfEnabled();
 }
 
 export default app;

--- a/server/src/mcp/README.md
+++ b/server/src/mcp/README.md
@@ -1,0 +1,153 @@
+# Codex MCP Server
+
+The Codex MCP (Model Context Protocol) server allows AI agents like Claude, GitHub Copilot, and other MCP-compatible clients to interact with your documentation wiki.
+
+*Architecture inspired by [streamable-mcp-server-template](https://github.com/iceener/streamable-mcp-server-template)*
+
+## Quick Start
+
+1. **Set an API key** for security:
+   ```bash
+   export MCP_API_KEY=your-secure-api-key
+   ```
+
+2. **Enable and start the MCP server**:
+   ```bash
+   # Development (with hot reload)
+   MCP_ENABLED=true npm run dev -w server
+
+   # Or use the dedicated script
+   npm run dev:mcp -w server
+   ```
+
+3. **Connect your MCP client** to:
+   ```
+   http://localhost:3002/mcp
+   ```
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MCP_ENABLED` | `false` | Enable/disable MCP server |
+| `MCP_PORT` | `3002` | Port for MCP server |
+| `MCP_HOST` | `0.0.0.0` | Host to bind to |
+| `MCP_API_KEY` | (none) | API key for authentication |
+| `MCP_SESSION_TTL_MS` | `86400000` | Session TTL (24 hours) |
+| `MCP_MAX_SESSIONS` | `100` | Max sessions per API key |
+| `MCP_DEBUG` | `false` | Enable debug logging |
+
+## Available Tools
+
+The MCP server exposes 12 tools:
+
+### Page Operations
+- **`search_pages`** - Search documentation by query string
+- **`get_page`** - Read a specific page's content
+- **`create_page`** - Create a new documentation page
+- **`update_page`** - Update an existing page
+- **`delete_page`** - Delete a page
+- **`rename_page`** - Rename a page
+- **`move_page`** - Move a page to a different folder
+
+### Folder Operations
+- **`list_folders`** - Get folder hierarchy
+- **`list_pages`** - List pages in a folder
+- **`create_folder`** - Create a new folder
+- **`delete_folder`** - Delete an empty folder
+- **`rename_folder`** - Rename a folder
+
+## Available Resources
+
+- **`codex://page/{path}`** - Access any documentation page by path
+- **`codex://folders`** - Get the complete folder structure as JSON
+
+## Authentication
+
+Set `MCP_API_KEY` to require authentication. Clients must provide the key via:
+- `Authorization: Bearer <key>` header, or
+- `X-Api-Key: <key>` header
+
+## Connecting with Claude Desktop
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "codex": {
+      "url": "http://localhost:3002/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-key"
+      }
+    }
+  }
+}
+```
+
+## Connecting with VS Code (GitHub Copilot)
+
+Configure in your VS Code settings or `mcp.json`:
+
+```json
+{
+  "servers": {
+    "codex": {
+      "type": "http",
+      "url": "http://localhost:3002/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-key"
+      }
+    }
+  }
+}
+```
+
+## API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/health` | GET | Health check |
+| `/.well-known/mcp` | GET | Server metadata |
+| `/mcp` | POST | MCP JSON-RPC messages |
+| `/mcp` | GET | SSE stream for server messages |
+| `/mcp` | DELETE | Terminate session |
+
+## Protocol Support
+
+Supports MCP protocol versions:
+- `2025-03-26` (latest)
+- `2024-11-05`
+
+Uses Streamable HTTP transport for web compatibility.
+
+## Security Considerations
+
+⚠️ **Production Deployment**:
+- Always set `MCP_API_KEY` for authentication
+- Run behind a reverse proxy with HTTPS
+- Use `MCP_HOST=127.0.0.1` to restrict to localhost if not proxying
+- Set `MCP_MAX_SESSIONS` appropriately for your use case
+
+## Example: Using from curl
+
+```bash
+# Health check
+curl http://localhost:3002/health
+
+# Initialize session
+# gitleaks:allow
+curl -X POST http://localhost:3002/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer your-api-key" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}},"id":1}'
+
+# List tools (use session ID from initialize response)
+# gitleaks:allow
+curl -X POST http://localhost:3002/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":2}'
+```

--- a/server/src/mcp/config.ts
+++ b/server/src/mcp/config.ts
@@ -1,0 +1,32 @@
+/**
+ * MCP Server Configuration
+ * Environment-based configuration for the MCP server.
+ */
+
+export interface McpConfig {
+  /** MCP server port (separate from main API) */
+  port: number;
+  /** Host to bind to */
+  host: string;
+  /** API key for authentication (required for production) */
+  apiKey: string | undefined;
+  /** Session TTL in milliseconds (default: 24 hours) */
+  sessionTtlMs: number;
+  /** Maximum sessions per API key */
+  maxSessionsPerKey: number;
+  /** Enable debug logging */
+  debug: boolean;
+}
+
+export function loadConfig(): McpConfig {
+  return {
+    port: parseInt(process.env.MCP_PORT || '3002', 10),
+    host: process.env.MCP_HOST || '0.0.0.0',
+    apiKey: process.env.MCP_API_KEY,
+    sessionTtlMs: parseInt(process.env.MCP_SESSION_TTL_MS || String(24 * 60 * 60 * 1000), 10),
+    maxSessionsPerKey: parseInt(process.env.MCP_MAX_SESSIONS || '5', 10),
+    debug: process.env.MCP_DEBUG === 'true',
+  };
+}
+
+export const config = loadConfig();

--- a/server/src/mcp/index.ts
+++ b/server/src/mcp/index.ts
@@ -1,0 +1,11 @@
+/**
+ * MCP Server Entry Point
+ *
+ * Can be run standalone or imported for integration with Express.
+ */
+
+export { startMcpServer } from './server';
+export { config } from './config';
+export { sessionStore } from './sessions';
+export { tools, registerTools } from './tools/registry';
+export { registerResources } from './resources';

--- a/server/src/mcp/resources.ts
+++ b/server/src/mcp/resources.ts
@@ -1,0 +1,82 @@
+/**
+ * MCP Resources
+ * Exposes documentation content as MCP resources for AI access.
+ */
+
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { fileSystemService } from '../index';
+import { config } from './config';
+
+/**
+ * Register all resources with an MCP server instance
+ */
+export function registerResources(server: McpServer): void {
+  // Resource template for pages - allows dynamic URI resolution
+  const pageTemplate = new ResourceTemplate(
+    'codex://page/{path}',
+    {
+      list: async () => {
+        // List all available pages from root folder
+        const pages = await fileSystemService.getPages('');
+        return {
+          resources: pages.map((page: { name: string; path: string }) => ({
+            uri: `codex://page/${encodeURIComponent(page.path)}`,
+            name: page.name,
+            description: `Documentation page: ${page.path}`,
+            mimeType: 'text/markdown',
+          })),
+        };
+      },
+    }
+  );
+
+  server.registerResource(
+    'Documentation Page',
+    pageTemplate,
+    {
+      description: 'A markdown documentation page from the Codex wiki',
+      mimeType: 'text/markdown',
+    },
+    async (uri: URL, _variables) => {
+      // Extract path from URI: codex://page/folder/file.md -> folder/file.md
+      const pagePath = decodeURIComponent(uri.pathname.replace(/^\//, ''));
+
+      try {
+        const content = await fileSystemService.getPageContent(pagePath);
+        return {
+          contents: [{
+            uri: uri.toString(),
+            mimeType: 'text/markdown',
+            text: content,
+          }],
+        };
+      } catch (error) {
+        throw new Error(`Page not found: ${pagePath}`);
+      }
+    }
+  );
+
+  // Static resource: folder tree
+  server.registerResource(
+    'Folder Structure',
+    'codex://folders',
+    {
+      description: 'The complete folder tree of the documentation',
+      mimeType: 'application/json',
+    },
+    async () => {
+      const tree = await fileSystemService.getFolderTree();
+      return {
+        contents: [{
+          uri: 'codex://folders',
+          mimeType: 'application/json',
+          text: JSON.stringify(tree, null, 2),
+        }],
+      };
+    }
+  );
+
+  if (config.debug) {
+    console.log('[MCP] Registered resources: codex://page/{path}, codex://folders');
+  }
+}

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -1,0 +1,296 @@
+/**
+ * Codex MCP Server
+ *
+ * A Model Context Protocol server that provides AI agents access to
+ * the Codex documentation wiki.
+ *
+ * Supports:
+ * - Streamable HTTP transport (latest MCP spec)
+ * - API key authentication
+ * - Session management
+ * - All Codex operations: search, read, create, update, delete pages/folders
+ *
+ * Protocol versions: 2025-03-26, 2024-11-05
+ */
+
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { config } from './config';
+import { sessionStore } from './sessions';
+import { registerTools } from './tools/registry';
+import { registerResources } from './resources';
+
+// Package version for server info
+const VERSION = '1.0.0';
+
+/**
+ * Create and configure the MCP server instance
+ */
+function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: 'codex',
+    version: VERSION,
+  });
+
+  // Register tools and resources
+  registerTools(server);
+  registerResources(server);
+
+  return server;
+}
+
+/**
+ * Validate API key from request headers
+ */
+function validateApiKey(req: IncomingMessage): boolean {
+  // If no API key configured, allow all (development mode)
+  if (!config.apiKey) {
+    if (config.debug) {
+      console.log('[MCP] Warning: No API key configured, accepting all requests');
+    }
+    return true;
+  }
+
+  const authHeader = req.headers['authorization'] || req.headers['x-api-key'];
+  if (!authHeader) {
+    return false;
+  }
+
+  const headerValue = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+
+  // Support both "Bearer <key>" and direct API key
+  if (headerValue.startsWith('Bearer ')) {
+    return headerValue.slice(7) === config.apiKey;
+  }
+
+  return headerValue === config.apiKey;
+}
+
+/**
+ * Extract API key for session binding
+ */
+function extractApiKey(req: IncomingMessage): string {
+  const authHeader = req.headers['authorization'] || req.headers['x-api-key'];
+
+  if (!authHeader) {
+    return 'public';
+  }
+
+  const headerValue = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+
+  if (headerValue.startsWith('Bearer ')) {
+    return headerValue.slice(7);
+  }
+
+  return headerValue;
+}
+
+/**
+ * Send JSON response
+ */
+function sendJson(res: ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+/**
+ * Parse request body as JSON
+ */
+function parseBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', chunk => chunks.push(chunk));
+    req.on('end', () => {
+      try {
+        const body = Buffer.concat(chunks).toString('utf-8');
+        resolve(body ? JSON.parse(body) : undefined);
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+// Store active transports per session
+const transports = new Map<string, StreamableHTTPServerTransport>();
+
+/**
+ * Start the MCP server
+ */
+export function startMcpServer(): void {
+  const mcpServer = createMcpServer();
+
+  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    // CORS headers
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Api-Key, Mcp-Session-Id');
+    res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+
+    // Handle preflight
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    const url = new URL(req.url || '/', `http://${req.headers.host}`);
+    const pathname = url.pathname;
+
+    // Health check endpoint
+    if (pathname === '/health' && req.method === 'GET') {
+      sendJson(res, 200, {
+        status: 'ok',
+        service: 'codex-mcp',
+        version: VERSION,
+        sessions: sessionStore.count(),
+        authRequired: Boolean(config.apiKey),
+      });
+      return;
+    }
+
+    // Well-known MCP server metadata
+    if (pathname === '/.well-known/mcp' && req.method === 'GET') {
+      sendJson(res, 200, {
+        name: 'codex',
+        version: VERSION,
+        description: 'Codex Documentation Wiki MCP Server',
+        capabilities: {
+          tools: true,
+          resources: true,
+          prompts: false,
+        },
+        endpoints: {
+          mcp: '/mcp',
+          health: '/health',
+        },
+        authentication: {
+          required: Boolean(config.apiKey),
+          methods: ['bearer', 'api_key'],
+        },
+      });
+      return;
+    }
+
+    // MCP endpoint
+    if (pathname === '/mcp') {
+      // Validate API key
+      if (!validateApiKey(req)) {
+        sendJson(res, 401, { error: 'Unauthorized' });
+        return;
+      }
+
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+      // Handle DELETE - session termination
+      if (req.method === 'DELETE') {
+        if (sessionId) {
+          const transport = transports.get(sessionId);
+          if (transport) {
+            await transport.close();
+            transports.delete(sessionId);
+          }
+          sessionStore.delete(sessionId);
+        }
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+
+      // Handle POST - MCP messages
+      if (req.method === 'POST') {
+        try {
+          // Get or create transport for this session
+          let transport: StreamableHTTPServerTransport;
+
+          if (sessionId && transports.has(sessionId)) {
+            transport = transports.get(sessionId)!;
+          } else {
+            // Create new transport
+            transport = new StreamableHTTPServerTransport({
+              sessionIdGenerator: () => {
+                const session = sessionStore.create(extractApiKey(req));
+                return session.id;
+              },
+              onsessioninitialized: (newSessionId) => {
+                sessionStore.initialize(newSessionId);
+                if (config.debug) {
+                  console.log(`[MCP] Session initialized: ${newSessionId}`);
+                }
+              },
+            });
+
+            // Connect MCP server to transport
+            await mcpServer.connect(transport);
+
+            // Store transport if session was created
+            if (transport.sessionId) {
+              transports.set(transport.sessionId, transport);
+            }
+          }
+
+          // Parse body and handle request
+          const body = await parseBody(req);
+          await transport.handleRequest(req, res, body);
+        } catch (error) {
+          console.error('[MCP] Request error:', error);
+          sendJson(res, 500, {
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: 'Internal error',
+              data: config.debug ? (error as Error).message : undefined,
+            },
+            id: null,
+          });
+        }
+        return;
+      }
+
+      // Handle GET - SSE streaming (for server-initiated messages)
+      if (req.method === 'GET') {
+        if (!sessionId || !transports.has(sessionId)) {
+          sendJson(res, 400, { error: 'Session ID required for SSE connection' });
+          return;
+        }
+
+        const transport = transports.get(sessionId)!;
+        await transport.handleRequest(req, res);
+        return;
+      }
+
+      // Method not allowed
+      sendJson(res, 405, { error: 'Method not allowed' });
+      return;
+    }
+
+    // Not found
+    sendJson(res, 404, { error: 'Not found' });
+  });
+
+  server.listen(config.port, config.host, () => {
+    console.log(`🤖 MCP Server started on http://${config.host}:${config.port}`);
+    console.log(`   Health: http://${config.host}:${config.port}/health`);
+    console.log(`   MCP endpoint: http://${config.host}:${config.port}/mcp`);
+    console.log(`   Auth required: ${Boolean(config.apiKey)}`);
+
+    if (!config.apiKey) {
+      console.log('   ⚠️  Warning: No MCP_API_KEY set - server is unauthenticated!');
+    }
+  });
+}
+
+// Graceful shutdown
+process.on('SIGINT', () => {
+  console.log('\n[MCP] Shutting down...');
+  sessionStore.stopCleanup();
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  console.log('\n[MCP] Shutting down...');
+  sessionStore.stopCleanup();
+  process.exit(0);
+});

--- a/server/src/mcp/sessions.ts
+++ b/server/src/mcp/sessions.ts
@@ -1,0 +1,156 @@
+/**
+ * MCP Session Store
+ * In-memory session management with TTL and per-key limits.
+ */
+
+import { config } from './config';
+
+interface Session {
+  id: string;
+  apiKey: string;
+  createdAt: number;
+  lastAccessedAt: number;
+  protocolVersion?: string;
+  initialized: boolean;
+}
+
+/**
+ * Simple in-memory session store with TTL and limits
+ */
+export class SessionStore {
+  private sessions = new Map<string, Session>();
+  private cleanupInterval: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    // Run cleanup every minute
+    this.cleanupInterval = setInterval(() => this.cleanup(), 60000);
+  }
+
+  /**
+   * Create a new session
+   */
+  create(apiKey: string): Session {
+    // Check per-key limit
+    const keySessions = this.getSessionsByApiKey(apiKey);
+    if (keySessions.length >= config.maxSessionsPerKey) {
+      // Remove oldest session for this API key (LRU)
+      const oldest = keySessions.sort((a, b) => a.lastAccessedAt - b.lastAccessedAt)[0];
+      if (oldest) {
+        this.delete(oldest.id);
+      }
+    }
+
+    const session: Session = {
+      id: crypto.randomUUID(),
+      apiKey,
+      createdAt: Date.now(),
+      lastAccessedAt: Date.now(),
+      initialized: false,
+    };
+
+    this.sessions.set(session.id, session);
+
+    if (config.debug) {
+      console.log(`[MCP] Session created: ${session.id}`);
+    }
+
+    return session;
+  }
+
+  /**
+   * Get a session by ID
+   */
+  get(sessionId: string): Session | undefined {
+    const session = this.sessions.get(sessionId);
+
+    if (!session) {
+      return undefined;
+    }
+
+    // Check TTL
+    if (Date.now() - session.lastAccessedAt > config.sessionTtlMs) {
+      this.delete(sessionId);
+      return undefined;
+    }
+
+    // Update last accessed time
+    session.lastAccessedAt = Date.now();
+    return session;
+  }
+
+  /**
+   * Mark session as initialized (after MCP handshake)
+   */
+  initialize(sessionId: string, protocolVersion?: string): boolean {
+    const session = this.get(sessionId);
+    if (!session) return false;
+
+    session.initialized = true;
+    session.protocolVersion = protocolVersion;
+    return true;
+  }
+
+  /**
+   * Delete a session
+   */
+  delete(sessionId: string): boolean {
+    const deleted = this.sessions.delete(sessionId);
+    if (deleted && config.debug) {
+      console.log(`[MCP] Session deleted: ${sessionId}`);
+    }
+    return deleted;
+  }
+
+  /**
+   * Validate session exists and is valid
+   */
+  validate(sessionId: string): boolean {
+    return this.get(sessionId) !== undefined;
+  }
+
+  /**
+   * Get all sessions for an API key
+   */
+  private getSessionsByApiKey(apiKey: string): Session[] {
+    return Array.from(this.sessions.values()).filter(s => s.apiKey === apiKey);
+  }
+
+  /**
+   * Clean up expired sessions
+   */
+  private cleanup(): void {
+    const now = Date.now();
+    let cleaned = 0;
+
+    for (const [id, session] of this.sessions) {
+      if (now - session.lastAccessedAt > config.sessionTtlMs) {
+        this.sessions.delete(id);
+        cleaned++;
+      }
+    }
+
+    if (cleaned > 0 && config.debug) {
+      console.log(`[MCP] Cleaned up ${cleaned} expired sessions`);
+    }
+  }
+
+  /**
+   * Stop cleanup interval (for graceful shutdown)
+   */
+  stopCleanup(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
+    }
+  }
+
+  /**
+   * Get session count (for health checks)
+   */
+  count(): number {
+    return this.sessions.size;
+  }
+}
+
+// Singleton instance
+export const sessionStore = new SessionStore();

--- a/server/src/mcp/tools/folders.ts
+++ b/server/src/mcp/tools/folders.ts
@@ -1,0 +1,194 @@
+/**
+ * MCP Tools - Folder Operations
+ * Tools for managing documentation folder structure.
+ */
+
+import { z } from 'zod';
+import { defineTool } from './types';
+import { fileSystemService } from '../../index';
+
+/**
+ * List folder structure
+ */
+export const listFoldersTool = defineTool({
+  name: 'list_folders',
+  description: 'Get the complete folder tree structure of the documentation. Returns all folders and their hierarchy.',
+  inputSchema: z.object({
+    path: z.string().optional().default('').describe('Starting path (empty for root)'),
+  }),
+  annotations: {
+    readOnlyHint: true,
+  },
+  handler: async (args, context) => {
+    if (context.signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+    }
+
+    try {
+      const tree = await fileSystemService.getFolderTree(args.path);
+
+      // Format tree as readable text
+      const formatTree = (node: { name: string; path: string; children?: Array<{ name: string; path: string; children?: unknown[] }> }, indent = 0): string => {
+        const prefix = '  '.repeat(indent);
+        let result = `${prefix}📁 ${node.name || 'root'}${node.path ? ` (${node.path})` : ''}\n`;
+        if (node.children) {
+          for (const child of node.children) {
+            result += formatTree(child as { name: string; path: string; children?: Array<{ name: string; path: string; children?: unknown[] }> }, indent + 1);
+          }
+        }
+        return result;
+      };
+
+      return {
+        content: [{ type: 'text', text: formatTree(tree) }],
+        structuredContent: { tree },
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Failed to list folders: ${(error as Error).message}` }],
+        isError: true,
+      };
+    }
+  },
+});
+
+/**
+ * List pages in a folder
+ */
+export const listPagesTool = defineTool({
+  name: 'list_pages',
+  description: 'List all documentation pages in a specific folder.',
+  inputSchema: z.object({
+    folder: z.string().optional().default('').describe('Folder path (empty for root)'),
+  }),
+  annotations: {
+    readOnlyHint: true,
+  },
+  handler: async (args, context) => {
+    if (context.signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+    }
+
+    try {
+      const pages = await fileSystemService.getPages(args.folder);
+
+      if (pages.length === 0) {
+        return {
+          content: [{ type: 'text', text: `No pages found in ${args.folder || 'root'}` }],
+          structuredContent: { folder: args.folder, pages: [] },
+        };
+      }
+
+      const pageList = pages.map(p => `📄 ${p.name} (modified: ${new Date(p.modifiedAt).toLocaleDateString()})`).join('\n');
+
+      return {
+        content: [{ type: 'text', text: `Pages in ${args.folder || 'root'}:\n\n${pageList}` }],
+        structuredContent: { folder: args.folder, pages },
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Failed to list pages: ${(error as Error).message}` }],
+        isError: true,
+      };
+    }
+  },
+});
+
+/**
+ * Create a new folder
+ */
+export const createFolderTool = defineTool({
+  name: 'create_folder',
+  description: 'Create a new folder for organizing documentation.',
+  inputSchema: z.object({
+    path: z.string().describe('Path for the new folder (e.g., "Projects/NewProject")'),
+  }),
+  annotations: {
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+  handler: async (args, context) => {
+    if (context.signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+    }
+
+    try {
+      await fileSystemService.createFolder(args.path);
+      return {
+        content: [{ type: 'text', text: `Successfully created folder: ${args.path}` }],
+        structuredContent: { path: args.path, created: true },
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Failed to create folder: ${(error as Error).message}` }],
+        isError: true,
+      };
+    }
+  },
+});
+
+/**
+ * Delete a folder
+ */
+export const deleteFolderTool = defineTool({
+  name: 'delete_folder',
+  description: 'Delete a folder and all its contents. This action cannot be undone!',
+  inputSchema: z.object({
+    path: z.string().describe('Path to the folder to delete'),
+  }),
+  annotations: {
+    destructiveHint: true,
+    idempotentHint: false,
+  },
+  handler: async (args, context) => {
+    if (context.signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+    }
+
+    try {
+      await fileSystemService.deleteFolder(args.path);
+      return {
+        content: [{ type: 'text', text: `Successfully deleted folder: ${args.path}` }],
+        structuredContent: { path: args.path, deleted: true },
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Failed to delete folder: ${(error as Error).message}` }],
+        isError: true,
+      };
+    }
+  },
+});
+
+/**
+ * Rename a folder
+ */
+export const renameFolderTool = defineTool({
+  name: 'rename_folder',
+  description: 'Rename a folder.',
+  inputSchema: z.object({
+    oldPath: z.string().describe('Current folder path'),
+    newPath: z.string().describe('New folder path'),
+  }),
+  annotations: {
+    destructiveHint: true,
+  },
+  handler: async (args, context) => {
+    if (context.signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+    }
+
+    try {
+      await fileSystemService.renameFolder(args.oldPath, args.newPath);
+      return {
+        content: [{ type: 'text', text: `Successfully renamed folder from ${args.oldPath} to ${args.newPath}` }],
+        structuredContent: { oldPath: args.oldPath, newPath: args.newPath, renamed: true },
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Failed to rename folder: ${(error as Error).message}` }],
+        isError: true,
+      };
+    }
+  },
+});

--- a/server/src/mcp/tools/pages.ts
+++ b/server/src/mcp/tools/pages.ts
@@ -1,0 +1,300 @@
+/**
+ * MCP Tools - Page Operations
+ * Tools for reading, creating, updating, and deleting documentation pages.
+ */
+
+import { z } from 'zod';
+import { defineTool } from './types';
+import { fileSystemService } from '../../index';
+
+/**
+ * Search documentation pages
+ */
+export const searchPagesTool = defineTool({
+  name: 'search_pages',
+  description: 'Search across all documentation pages for a query string. Returns matching pages with snippets and match counts.',
+  inputSchema: z.object({
+    query: z.string().min(1).describe('Search query to find in page content'),
+    maxResults: z.number().optional().default(20).describe('Maximum number of results to return'),
+  }),
+  annotations: {
+    readOnlyHint: true,
+  },
+  handler: async (args, context) => {
+    if (context.signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+    }
+
+    const searchTerm = args.query.toLowerCase().trim();
+    const results: Array<{
+      path: string;
+      title: string;
+      snippet: string;
+      matches: number;
+    }> = [];
+
+    // Get all folders recursively
+    const getAllFolders = async (node: { path?: string; children?: Array<{ path?: string; children?: unknown[] }> }, folders: string[] = []): Promise<string[]> => {
+      folders.push(node.path || '');
+      if (node.children) {
+        for (const child of node.children) {
+          await getAllFolders(child as { path?: string; children?: Array<{ path?: string; children?: unknown[] }> }, folders);
+        }
+      }
+      return folders;
+    };
+
+    const folderTree = await fileSystemService.getFolderTree();
+    const allFolders = await getAllFolders(folderTree);
+
+    for (const folderPath of allFolders) {
+      const pages = await fileSystemService.getPages(folderPath);
+
+      for (const page of pages) {
+        if (context.signal?.aborted) {
+          return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+        }
+
+        try {
+          const content = await fileSystemService.getPageContent(page.path);
+          const lowerContent = content.toLowerCase();
+          const parts = lowerContent.split(searchTerm);
+          const matches = parts.length - 1;
+
+          if (matches > 0) {
+            const index = lowerContent.indexOf(searchTerm);
+            const start = Math.max(0, index - 50);
+            const end = Math.min(content.length, index + searchTerm.length + 50);
+            let snippet = content.substring(start, end);
+
+            if (start > 0) snippet = '...' + snippet;
+            if (end < content.length) snippet = snippet + '...';
+
+            results.push({
+              path: page.path,
+              title: page.name.replace('.md', ''),
+              snippet,
+              matches,
+            });
+          }
+        } catch {
+          // Skip pages that fail to read
+        }
+      }
+    }
+
+    results.sort((a, b) => b.matches - a.matches);
+    const limitedResults = results.slice(0, args.maxResults);
+
+    return {
+      content: [{
+        type: 'text',
+        text: limitedResults.length > 0
+          ? `Found ${results.length} matches:\n\n${limitedResults.map(r => `**${r.title}** (${r.path})\n${r.snippet}\n_${r.matches} matches_`).join('\n\n')}`
+          : `No matches found for "${args.query}"`,
+      }],
+      structuredContent: { results: limitedResults, total: results.length },
+    };
+  },
+});
+
+/**
+ * Get page content
+ */
+export const getPageTool = defineTool({
+  name: 'get_page',
+  description: 'Read the full content of a documentation page by its path.',
+  inputSchema: z.object({
+    path: z.string().describe('Path to the page (e.g., "folder/page.md" or "Welcome.md")'),
+  }),
+  annotations: {
+    readOnlyHint: true,
+  },
+  handler: async (args, context) => {
+    if (context.signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+    }
+
+    try {
+      const content = await fileSystemService.getPageContent(args.path);
+      return {
+        content: [{ type: 'text', text: content }],
+        structuredContent: { path: args.path, content },
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Failed to read page: ${(error as Error).message}` }],
+        isError: true,
+      };
+    }
+  },
+});
+
+/**
+ * Create a new page
+ */
+export const createPageTool = defineTool({
+  name: 'create_page',
+  description: 'Create a new documentation page with the specified content.',
+  inputSchema: z.object({
+    path: z.string().describe('Path for the new page (e.g., "folder/new-page.md")'),
+    content: z.string().describe('Markdown content for the page'),
+  }),
+  annotations: {
+    destructiveHint: false,
+    idempotentHint: false,
+  },
+  handler: async (args, context) => {
+    if (context.signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+    }
+
+    try {
+      // Ensure path ends with .md
+      const pagePath = args.path.endsWith('.md') ? args.path : `${args.path}.md`;
+      await fileSystemService.createPage(pagePath, args.content);
+      return {
+        content: [{ type: 'text', text: `Successfully created page: ${pagePath}` }],
+        structuredContent: { path: pagePath, created: true },
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Failed to create page: ${(error as Error).message}` }],
+        isError: true,
+      };
+    }
+  },
+});
+
+/**
+ * Update an existing page
+ */
+export const updatePageTool = defineTool({
+  name: 'update_page',
+  description: 'Update the content of an existing documentation page. Replaces the entire content.',
+  inputSchema: z.object({
+    path: z.string().describe('Path to the page to update'),
+    content: z.string().describe('New markdown content for the page'),
+  }),
+  annotations: {
+    destructiveHint: true,
+    idempotentHint: true,
+  },
+  handler: async (args, context) => {
+    if (context.signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+    }
+
+    try {
+      await fileSystemService.updatePage(args.path, args.content);
+      return {
+        content: [{ type: 'text', text: `Successfully updated page: ${args.path}` }],
+        structuredContent: { path: args.path, updated: true },
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Failed to update page: ${(error as Error).message}` }],
+        isError: true,
+      };
+    }
+  },
+});
+
+/**
+ * Delete a page
+ */
+export const deletePageTool = defineTool({
+  name: 'delete_page',
+  description: 'Delete a documentation page. This action cannot be undone (though Git history preserves it).',
+  inputSchema: z.object({
+    path: z.string().describe('Path to the page to delete'),
+  }),
+  annotations: {
+    destructiveHint: true,
+    idempotentHint: false,
+  },
+  handler: async (args, context) => {
+    if (context.signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+    }
+
+    try {
+      await fileSystemService.deletePage(args.path);
+      return {
+        content: [{ type: 'text', text: `Successfully deleted page: ${args.path}` }],
+        structuredContent: { path: args.path, deleted: true },
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Failed to delete page: ${(error as Error).message}` }],
+        isError: true,
+      };
+    }
+  },
+});
+
+/**
+ * Rename a page
+ */
+export const renamePageTool = defineTool({
+  name: 'rename_page',
+  description: 'Rename a documentation page (changes filename only, not folder).',
+  inputSchema: z.object({
+    oldPath: z.string().describe('Current path of the page'),
+    newPath: z.string().describe('New path for the page'),
+  }),
+  annotations: {
+    destructiveHint: true,
+  },
+  handler: async (args, context) => {
+    if (context.signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+    }
+
+    try {
+      await fileSystemService.renamePage(args.oldPath, args.newPath);
+      return {
+        content: [{ type: 'text', text: `Successfully renamed page from ${args.oldPath} to ${args.newPath}` }],
+        structuredContent: { oldPath: args.oldPath, newPath: args.newPath, renamed: true },
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Failed to rename page: ${(error as Error).message}` }],
+        isError: true,
+      };
+    }
+  },
+});
+
+/**
+ * Move a page to a different folder
+ */
+export const movePageTool = defineTool({
+  name: 'move_page',
+  description: 'Move a documentation page to a different folder.',
+  inputSchema: z.object({
+    path: z.string().describe('Current path of the page'),
+    newFolder: z.string().describe('Destination folder path (empty string for root)'),
+  }),
+  annotations: {
+    destructiveHint: true,
+  },
+  handler: async (args, context) => {
+    if (context.signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Operation cancelled' }], isError: true };
+    }
+
+    try {
+      const newPath = await fileSystemService.movePage(args.path, args.newFolder);
+      return {
+        content: [{ type: 'text', text: `Successfully moved page to ${newPath}` }],
+        structuredContent: { oldPath: args.path, newPath, moved: true },
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Failed to move page: ${(error as Error).message}` }],
+        isError: true,
+      };
+    }
+  },
+});

--- a/server/src/mcp/tools/registry.ts
+++ b/server/src/mcp/tools/registry.ts
@@ -1,0 +1,155 @@
+/**
+ * MCP Tool Registry
+ * Central registration point for all Codex MCP tools.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { config } from '../config';
+import type { RegisteredTool, ToolContext, ToolResult } from './types';
+import { asRegisteredTool } from './types';
+
+// Import all tools
+import {
+  searchPagesTool,
+  getPageTool,
+  createPageTool,
+  updatePageTool,
+  deletePageTool,
+  renamePageTool,
+  movePageTool,
+} from './pages';
+
+import {
+  listFoldersTool,
+  listPagesTool,
+  createFolderTool,
+  deleteFolderTool,
+  renameFolderTool,
+} from './folders';
+
+/**
+ * All registered tools
+ */
+export const tools: RegisteredTool[] = [
+  // Page operations
+  asRegisteredTool(searchPagesTool),
+  asRegisteredTool(getPageTool),
+  asRegisteredTool(createPageTool),
+  asRegisteredTool(updatePageTool),
+  asRegisteredTool(deletePageTool),
+  asRegisteredTool(renamePageTool),
+  asRegisteredTool(movePageTool),
+  // Folder operations
+  asRegisteredTool(listFoldersTool),
+  asRegisteredTool(listPagesTool),
+  asRegisteredTool(createFolderTool),
+  asRegisteredTool(deleteFolderTool),
+  asRegisteredTool(renameFolderTool),
+];
+
+/**
+ * Get a tool by name
+ */
+export function getTool(name: string): RegisteredTool | undefined {
+  return tools.find(t => t.name === name);
+}
+
+/**
+ * Execute a tool by name with input validation
+ */
+export async function executeTool(
+  name: string,
+  args: Record<string, unknown>,
+  context: ToolContext
+): Promise<ToolResult> {
+  const tool = getTool(name);
+
+  if (!tool) {
+    return {
+      content: [{ type: 'text', text: `Unknown tool: ${name}` }],
+      isError: true,
+    };
+  }
+
+  // Check for cancellation
+  if (context.signal?.aborted) {
+    return {
+      content: [{ type: 'text', text: 'Operation was cancelled' }],
+      isError: true,
+    };
+  }
+
+  // Validate input with Zod
+  const parseResult = tool.inputSchema.safeParse(args);
+  if (!parseResult.success) {
+    const errors = parseResult.error.issues
+      .map(e => `${e.path.join('.')}: ${e.message}`)
+      .join(', ');
+    return {
+      content: [{ type: 'text', text: `Invalid input: ${errors}` }],
+      isError: true,
+    };
+  }
+
+  try {
+    const result = await tool.handler(parseResult.data, context);
+    return result;
+  } catch (error) {
+    if (context.signal?.aborted) {
+      return {
+        content: [{ type: 'text', text: 'Operation was cancelled' }],
+        isError: true,
+      };
+    }
+    return {
+      content: [{ type: 'text', text: `Tool error: ${(error as Error).message}` }],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Extra data passed to tool handlers by the SDK
+ */
+interface ToolHandlerExtra {
+  sessionId?: string;
+  requestId?: string | number;
+  signal?: AbortSignal;
+  _meta?: {
+    progressToken?: string | number;
+  };
+}
+
+/**
+ * Register all tools with an MCP server instance
+ */
+export function registerTools(server: McpServer): void {
+  for (const tool of tools) {
+    server.registerTool(
+      tool.name,
+      {
+        description: tool.description,
+        inputSchema: tool.inputSchema.shape,
+        ...(tool.annotations && { annotations: tool.annotations }),
+      },
+      async (args: Record<string, unknown>, extra: ToolHandlerExtra) => {
+        const context: ToolContext = {
+          sessionId: extra.sessionId ?? crypto.randomUUID(),
+          signal: extra.signal,
+          meta: {
+            progressToken: extra._meta?.progressToken,
+            requestId: extra.requestId?.toString(),
+          },
+        };
+
+        const result = await executeTool(tool.name, args, context);
+        return result as CallToolResult;
+      }
+    );
+  }
+
+  if (config.debug) {
+    console.log(`[MCP] Registered ${tools.length} tools: ${tools.map(t => t.name).join(', ')}`);
+  }
+}

--- a/server/src/mcp/tools/types.ts
+++ b/server/src/mcp/tools/types.ts
@@ -1,0 +1,80 @@
+/**
+ * MCP Tool Types and Utilities
+ * Based on the latest MCP SDK patterns.
+ */
+
+import type { ZodObject, ZodRawShape, z } from 'zod';
+
+/**
+ * Context passed to every tool handler.
+ */
+export interface ToolContext {
+  /** Session ID for this request */
+  sessionId: string;
+  /** AbortSignal for cancellation support */
+  signal?: AbortSignal;
+  /** Additional metadata */
+  meta?: {
+    progressToken?: string | number;
+    requestId?: string;
+  };
+}
+
+/**
+ * Result returned by tool handlers.
+ * Per MCP spec: content is always required, structuredContent when outputSchema defined.
+ */
+export interface ToolResult {
+  content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}
+
+/**
+ * Tool definition with typed input schema.
+ */
+export interface ToolDefinition<T extends ZodRawShape> {
+  name: string;
+  description: string;
+  inputSchema: ZodObject<T>;
+  annotations?: {
+    /** Tool doesn't modify data */
+    readOnlyHint?: boolean;
+    /** Tool may cause destructive/irreversible changes */
+    destructiveHint?: boolean;
+    /** Tool can be safely retried */
+    idempotentHint?: boolean;
+    /** Tool interacts with external systems */
+    openWorldHint?: boolean;
+  };
+  handler: (args: z.infer<ZodObject<T>>, context: ToolContext) => Promise<ToolResult>;
+}
+
+/**
+ * Helper to define a tool with proper typing.
+ */
+export function defineTool<T extends ZodRawShape>(
+  definition: ToolDefinition<T>
+): ToolDefinition<T> {
+  return definition;
+}
+
+/**
+ * Registered tool with erased generic for storage in arrays.
+ */
+export interface RegisteredTool {
+  name: string;
+  description: string;
+  inputSchema: ZodObject<ZodRawShape>;
+  annotations?: Record<string, unknown>;
+  handler: (args: Record<string, unknown>, context: ToolContext) => Promise<ToolResult>;
+}
+
+/**
+ * Convert a typed ToolDefinition to RegisteredTool.
+ */
+export function asRegisteredTool<T extends ZodRawShape>(
+  tool: ToolDefinition<T>
+): RegisteredTool {
+  return tool as unknown as RegisteredTool;
+}

--- a/server/tests/mcp-test.sh
+++ b/server/tests/mcp-test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Simple MCP server test script
+
+BASE_URL="http://localhost:3002"
+
+echo "=== Testing MCP Server ==="
+echo ""
+
+# Health check
+echo "1. Health Check:"
+curl -s "$BASE_URL/health" | jq .
+echo ""
+
+# Well-known MCP
+echo "2. Well-known MCP metadata:"
+curl -s "$BASE_URL/.well-known/mcp" | jq .
+echo ""
+
+# Initialize session
+echo "3. Initialize MCP session:"
+RESPONSE=$(curl -s -X POST "$BASE_URL/mcp" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -D - \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}')
+
+SESSION_ID=$(echo "$RESPONSE" | grep -i "mcp-session-id:" | awk '{print $2}' | tr -d '\r')
+echo "Session ID: $SESSION_ID"
+echo "$RESPONSE" | grep "data:" | sed 's/data: //' | jq .
+echo ""
+
+echo "=== MCP Server tests complete ==="

--- a/server/tests/mcp.test.ts
+++ b/server/tests/mcp.test.ts
@@ -1,0 +1,839 @@
+/**
+ * MCP Server Tests
+ * Comprehensive tests for the Model Context Protocol server.
+ */
+
+import request from 'supertest';
+import { createServer, Server, IncomingMessage, ServerResponse } from 'http';
+import { setServices } from '../src/index';
+import { FileSystemService } from '../src/services/fileSystem';
+import { GitService } from '../src/services/gitService';
+import fs from 'fs/promises';
+import path from 'path';
+
+// Import MCP components for unit testing
+import { SessionStore, sessionStore as globalSessionStore } from '../src/mcp/sessions';
+import { loadConfig } from '../src/mcp/config';
+import { tools, getTool, executeTool } from '../src/mcp/tools/registry';
+
+const TEST_DATA_DIR = path.join(__dirname, '../test-data-mcp');
+
+// Stop the global singleton's cleanup interval after all tests
+afterAll(() => {
+  globalSessionStore.stopCleanup();
+});
+
+// ============================================================================
+// Unit Tests: Session Store
+// ============================================================================
+
+describe('MCP Session Store', () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    // Create a fresh session store for each test
+    store = new SessionStore();
+  });
+
+  afterEach(() => {
+    store.stopCleanup();
+  });
+
+  describe('Session Creation', () => {
+    it('should create a new session with unique ID', () => {
+      const session = store.create('test-api-key');
+
+      expect(session).toBeDefined();
+      expect(session.id).toBeDefined();
+      expect(session.id.length).toBeGreaterThan(0);
+      expect(session.apiKey).toBe('test-api-key');
+      expect(session.initialized).toBe(false);
+    });
+
+    it('should create sessions with unique IDs', () => {
+      const session1 = store.create('test-api-key');
+      const session2 = store.create('test-api-key');
+
+      expect(session1.id).not.toBe(session2.id);
+    });
+
+    it('should track creation and last accessed time', () => {
+      const before = Date.now();
+      const session = store.create('test-api-key');
+      const after = Date.now();
+
+      expect(session.createdAt).toBeGreaterThanOrEqual(before);
+      expect(session.createdAt).toBeLessThanOrEqual(after);
+      expect(session.lastAccessedAt).toBeGreaterThanOrEqual(before);
+      expect(session.lastAccessedAt).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('Session Retrieval', () => {
+    it('should retrieve an existing session', () => {
+      const created = store.create('test-api-key');
+      const retrieved = store.get(created.id);
+
+      expect(retrieved).toBeDefined();
+      expect(retrieved!.id).toBe(created.id);
+    });
+
+    it('should return undefined for non-existent session', () => {
+      const retrieved = store.get('non-existent-id');
+
+      expect(retrieved).toBeUndefined();
+    });
+
+    it('should update lastAccessedAt on retrieval', async () => {
+      const created = store.create('test-api-key');
+      const initialAccessTime = created.lastAccessedAt;
+
+      // Wait a tiny bit
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const retrieved = store.get(created.id);
+
+      expect(retrieved!.lastAccessedAt).toBeGreaterThan(initialAccessTime);
+    });
+  });
+
+  describe('Session Initialization', () => {
+    it('should mark session as initialized', () => {
+      const session = store.create('test-api-key');
+      expect(session.initialized).toBe(false);
+
+      const result = store.initialize(session.id, '2024-11-05');
+
+      expect(result).toBe(true);
+
+      const retrieved = store.get(session.id);
+      expect(retrieved!.initialized).toBe(true);
+      expect(retrieved!.protocolVersion).toBe('2024-11-05');
+    });
+
+    it('should return false for non-existent session', () => {
+      const result = store.initialize('non-existent', '2024-11-05');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('Session Deletion', () => {
+    it('should delete an existing session', () => {
+      const session = store.create('test-api-key');
+      expect(store.get(session.id)).toBeDefined();
+
+      const deleted = store.delete(session.id);
+
+      expect(deleted).toBe(true);
+      expect(store.get(session.id)).toBeUndefined();
+    });
+
+    it('should return false when deleting non-existent session', () => {
+      const deleted = store.delete('non-existent');
+
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe('Session Validation', () => {
+    it('should validate existing session', () => {
+      const session = store.create('test-api-key');
+
+      expect(store.validate(session.id)).toBe(true);
+    });
+
+    it('should not validate non-existent session', () => {
+      expect(store.validate('non-existent')).toBe(false);
+    });
+
+    it('should not validate deleted session', () => {
+      const session = store.create('test-api-key');
+      store.delete(session.id);
+
+      expect(store.validate(session.id)).toBe(false);
+    });
+  });
+
+  describe('Session Count', () => {
+    it('should return correct session count', () => {
+      expect(store.count()).toBe(0);
+
+      store.create('key1');
+      expect(store.count()).toBe(1);
+
+      store.create('key2');
+      expect(store.count()).toBe(2);
+    });
+
+    it('should decrease count on deletion', () => {
+      const session = store.create('test-api-key');
+      expect(store.count()).toBe(1);
+
+      store.delete(session.id);
+      expect(store.count()).toBe(0);
+    });
+  });
+
+  describe('Per-Key Session Limits', () => {
+    it('should enforce max sessions per API key by removing oldest', () => {
+      // Create sessions up to the limit (default is 5)
+      const sessions = [];
+      for (let i = 0; i < 5; i++) {
+        sessions.push(store.create('same-api-key'));
+      }
+
+      // All 5 should exist
+      expect(store.count()).toBe(5);
+
+      // Create one more - should evict the oldest
+      const newSession = store.create('same-api-key');
+
+      // Still 5 sessions (oldest was evicted)
+      expect(store.count()).toBe(5);
+
+      // First session should be gone
+      expect(store.get(sessions[0].id)).toBeUndefined();
+
+      // New session should exist
+      expect(store.get(newSession.id)).toBeDefined();
+    });
+
+    it('should allow different API keys to have separate limits', () => {
+      // Create 3 sessions for key1
+      for (let i = 0; i < 3; i++) {
+        store.create('key1');
+      }
+
+      // Create 3 sessions for key2
+      for (let i = 0; i < 3; i++) {
+        store.create('key2');
+      }
+
+      expect(store.count()).toBe(6);
+    });
+  });
+});
+
+// ============================================================================
+// Unit Tests: Configuration
+// ============================================================================
+
+describe('MCP Configuration', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should load default configuration', () => {
+    delete process.env.MCP_PORT;
+    delete process.env.MCP_HOST;
+    delete process.env.MCP_API_KEY;
+    delete process.env.MCP_SESSION_TTL_MS;
+    delete process.env.MCP_MAX_SESSIONS;
+    delete process.env.MCP_DEBUG;
+
+    const config = loadConfig();
+
+    expect(config.port).toBe(3002);
+    expect(config.host).toBe('0.0.0.0');
+    expect(config.apiKey).toBeUndefined();
+    expect(config.sessionTtlMs).toBe(24 * 60 * 60 * 1000);
+    expect(config.maxSessionsPerKey).toBe(5);
+    expect(config.debug).toBe(false);
+  });
+
+  it('should load custom configuration from environment', () => {
+    process.env.MCP_PORT = '4000';
+    process.env.MCP_HOST = '127.0.0.1';
+    process.env.MCP_API_KEY = 'test-key';
+    process.env.MCP_SESSION_TTL_MS = '3600000';
+    process.env.MCP_MAX_SESSIONS = '10';
+    process.env.MCP_DEBUG = 'true';
+
+    const config = loadConfig();
+
+    expect(config.port).toBe(4000);
+    expect(config.host).toBe('127.0.0.1');
+    expect(config.apiKey).toBe('test-key');
+    expect(config.sessionTtlMs).toBe(3600000);
+    expect(config.maxSessionsPerKey).toBe(10);
+    expect(config.debug).toBe(true);
+  });
+});
+
+// ============================================================================
+// Unit Tests: Tool Registry
+// ============================================================================
+
+describe('MCP Tool Registry', () => {
+  describe('Tool Registration', () => {
+    it('should have 12 registered tools', () => {
+      expect(tools).toHaveLength(12);
+    });
+
+    it('should register all page tools', () => {
+      const pageToolNames = [
+        'search_pages',
+        'get_page',
+        'create_page',
+        'update_page',
+        'delete_page',
+        'rename_page',
+        'move_page',
+      ];
+
+      for (const name of pageToolNames) {
+        expect(getTool(name)).toBeDefined();
+      }
+    });
+
+    it('should register all folder tools', () => {
+      const folderToolNames = [
+        'list_folders',
+        'list_pages',
+        'create_folder',
+        'delete_folder',
+        'rename_folder',
+      ];
+
+      for (const name of folderToolNames) {
+        expect(getTool(name)).toBeDefined();
+      }
+    });
+
+    it('should return undefined for unknown tool', () => {
+      expect(getTool('unknown_tool')).toBeUndefined();
+    });
+  });
+
+  describe('Tool Structure', () => {
+    it('each tool should have required properties', () => {
+      for (const tool of tools) {
+        expect(tool.name).toBeDefined();
+        expect(typeof tool.name).toBe('string');
+        expect(tool.description).toBeDefined();
+        expect(typeof tool.description).toBe('string');
+        expect(tool.inputSchema).toBeDefined();
+        expect(tool.handler).toBeDefined();
+        expect(typeof tool.handler).toBe('function');
+      }
+    });
+
+    it('each tool should have a valid Zod input schema', () => {
+      for (const tool of tools) {
+        // Verify it's a Zod schema by checking for safeParse
+        expect(typeof tool.inputSchema.safeParse).toBe('function');
+      }
+    });
+  });
+
+  describe('Tool Execution', () => {
+    it('should return error for unknown tool', async () => {
+      const result = await executeTool('unknown_tool', {}, { sessionId: 'test' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]).toMatchObject({
+        type: 'text',
+        text: expect.stringContaining('Unknown tool'),
+      });
+    });
+
+    it('should return error for invalid input', async () => {
+      // get_page requires 'path' parameter
+      const result = await executeTool('get_page', {}, { sessionId: 'test' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]).toMatchObject({
+        type: 'text',
+        text: expect.stringContaining('Invalid input'),
+      });
+    });
+
+    it('should handle cancellation', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await executeTool(
+        'search_pages',
+        { query: 'test' },
+        { sessionId: 'test', signal: controller.signal }
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]).toMatchObject({
+        type: 'text',
+        text: 'Operation was cancelled',
+      });
+    });
+  });
+});
+
+// ============================================================================
+// Integration Tests: MCP HTTP Server
+// ============================================================================
+
+describe('MCP HTTP Server Integration', () => {
+  let testGitService: GitService;
+  let testFileSystemService: FileSystemService;
+  let mcpServer: Server | null = null;
+  let testSessionStore: SessionStore | null = null;
+  const MCP_PORT = 3099; // Use different port for tests
+
+  beforeAll(async () => {
+    // Create test directory
+    await fs.mkdir(TEST_DATA_DIR, { recursive: true });
+
+    // Create Git and FileSystem services
+    testGitService = new GitService(TEST_DATA_DIR);
+    testFileSystemService = new FileSystemService(TEST_DATA_DIR, testGitService);
+
+    await testFileSystemService.initialize();
+    await testGitService.initialize();
+
+    // Override the app's services
+    setServices(testGitService, testFileSystemService);
+
+    // Create some test data
+    await testFileSystemService.createPage('test-page.md', '# Test Page\n\nTest content');
+    await testFileSystemService.createFolder('test-folder');
+  });
+
+  afterAll(async () => {
+    if (mcpServer) {
+      mcpServer.close();
+      mcpServer = null;
+    }
+
+    if (testSessionStore) {
+      testSessionStore.stopCleanup();
+      testSessionStore = null;
+    }
+
+    // Clean up test data
+    try {
+      await fs.rm(TEST_DATA_DIR, { recursive: true, force: true });
+    } catch (error) {
+      // Ignore errors
+    }
+  });
+
+  // Helper to create a simple test server that mimics MCP endpoints
+  function createTestMcpServer(): Server {
+    // Create a new session store for this test server
+    testSessionStore = new SessionStore();
+
+    return createServer(async (req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url || '/', `http://localhost:${MCP_PORT}`);
+
+      // CORS headers
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Api-Key, Mcp-Session-Id');
+
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+
+      // Health endpoint
+      if (url.pathname === '/health' && req.method === 'GET') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          status: 'ok',
+          service: 'codex-mcp',
+          version: '1.0.0',
+          sessions: testSessionStore ? testSessionStore.count() : 0,
+          authRequired: false,
+        }));
+        return;
+      }
+
+      // Well-known MCP metadata
+      if (url.pathname === '/.well-known/mcp' && req.method === 'GET') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          name: 'codex',
+          version: '1.0.0',
+          description: 'Codex Documentation Wiki MCP Server',
+          capabilities: {
+            tools: true,
+            resources: true,
+            prompts: false,
+          },
+        }));
+        return;
+      }
+
+      // Not found
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+    });
+  }
+
+  describe('Health Endpoint', () => {
+    beforeAll(async () => {
+      mcpServer = createTestMcpServer();
+      await new Promise<void>((resolve) => {
+        mcpServer!.listen(MCP_PORT, () => resolve());
+      });
+    });
+
+    afterAll(() => {
+      if (mcpServer) {
+        mcpServer.close();
+        mcpServer = null;
+      }
+      if (testSessionStore) {
+        testSessionStore.stopCleanup();
+        testSessionStore = null;
+      }
+    });
+
+    it('should return health status', async () => {
+      const response = await fetch(`http://localhost:${MCP_PORT}/health`);
+      const data = await response.json() as {
+        status: string;
+        service: string;
+        version: string;
+        sessions: number;
+      };
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe('ok');
+      expect(data.service).toBe('codex-mcp');
+      expect(data.version).toBe('1.0.0');
+      expect(typeof data.sessions).toBe('number');
+    });
+  });
+
+  describe('Well-Known MCP Metadata', () => {
+    beforeAll(async () => {
+      if (!mcpServer) {
+        mcpServer = createTestMcpServer();
+        await new Promise<void>((resolve) => {
+          mcpServer!.listen(MCP_PORT, () => resolve());
+        });
+      }
+    });
+
+    afterAll(() => {
+      if (mcpServer) {
+        mcpServer.close();
+        mcpServer = null;
+      }
+      if (testSessionStore) {
+        testSessionStore.stopCleanup();
+        testSessionStore = null;
+      }
+    });
+
+    it('should return MCP server metadata', async () => {
+      const response = await fetch(`http://localhost:${MCP_PORT}/.well-known/mcp`);
+      const data = await response.json() as {
+        name: string;
+        version: string;
+        capabilities: { tools: boolean; resources: boolean };
+      };
+
+      expect(response.status).toBe(200);
+      expect(data.name).toBe('codex');
+      expect(data.version).toBe('1.0.0');
+      expect(data.capabilities.tools).toBe(true);
+      expect(data.capabilities.resources).toBe(true);
+    });
+  });
+
+  describe('CORS Headers', () => {
+    beforeAll(async () => {
+      if (!mcpServer) {
+        mcpServer = createTestMcpServer();
+        await new Promise<void>((resolve) => {
+          mcpServer!.listen(MCP_PORT, () => resolve());
+        });
+      }
+    });
+
+    afterAll(() => {
+      if (mcpServer) {
+        mcpServer.close();
+        mcpServer = null;
+      }
+      if (testSessionStore) {
+        testSessionStore.stopCleanup();
+        testSessionStore = null;
+      }
+    });
+
+    it('should include CORS headers in response', async () => {
+      const response = await fetch(`http://localhost:${MCP_PORT}/health`);
+
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    });
+
+    it('should handle OPTIONS preflight request', async () => {
+      const response = await fetch(`http://localhost:${MCP_PORT}/mcp`, {
+        method: 'OPTIONS',
+      });
+
+      expect(response.status).toBe(204);
+    });
+  });
+});
+
+// ============================================================================
+// Integration Tests: Tool Execution with FileSystem
+// ============================================================================
+
+describe('MCP Tools with FileSystem', () => {
+  let testGitService: GitService;
+  let testFileSystemService: FileSystemService;
+
+  beforeAll(async () => {
+    await fs.mkdir(TEST_DATA_DIR, { recursive: true });
+
+    testGitService = new GitService(TEST_DATA_DIR);
+    testFileSystemService = new FileSystemService(TEST_DATA_DIR, testGitService);
+
+    await testFileSystemService.initialize();
+    await testGitService.initialize();
+
+    setServices(testGitService, testFileSystemService);
+  });
+
+  afterAll(async () => {
+    try {
+      await fs.rm(TEST_DATA_DIR, { recursive: true, force: true });
+    } catch (error) {
+      // Ignore errors
+    }
+  });
+
+  beforeEach(async () => {
+    // Clean test directory before each test
+    try {
+      await fs.rm(TEST_DATA_DIR, { recursive: true, force: true });
+      await fs.mkdir(TEST_DATA_DIR, { recursive: true });
+      await testGitService.initialize();
+    } catch (error) {
+      // Ignore errors
+    }
+  });
+
+  describe('list_folders Tool', () => {
+    it('should list empty folder structure', async () => {
+      const result = await executeTool('list_folders', {}, { sessionId: 'test' });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].type).toBe('text');
+
+      // Tool returns human-readable text format with emoji
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('📁');
+      expect(text).toContain('root');
+    });
+
+    it('should list created folders', async () => {
+      await testFileSystemService.createFolder('folder1');
+      await testFileSystemService.createFolder('folder2');
+
+      const result = await executeTool('list_folders', {}, { sessionId: 'test' });
+
+      expect(result.isError).toBeFalsy();
+
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('folder1');
+      expect(text).toContain('folder2');
+    });
+  });
+
+  describe('create_folder Tool', () => {
+    it('should create a new folder', async () => {
+      const result = await executeTool(
+        'create_folder',
+        { path: 'new-folder' },
+        { sessionId: 'test' }
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect((result.content[0] as { text: string }).text).toContain('created');
+
+      // Verify folder exists
+      const stats = await fs.stat(path.join(TEST_DATA_DIR, 'new-folder'));
+      expect(stats.isDirectory()).toBe(true);
+    });
+
+    it('should return error for invalid folder path', async () => {
+      const result = await executeTool(
+        'create_folder',
+        { path: '../outside' },
+        { sessionId: 'test' }
+      );
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('create_page Tool', () => {
+    it('should create a new page', async () => {
+      const result = await executeTool(
+        'create_page',
+        {
+          path: 'test-page.md',
+          content: '# Test\n\nContent here',
+        },
+        { sessionId: 'test' }
+      );
+
+      expect(result.isError).toBeFalsy();
+
+      // Verify page exists
+      const content = await fs.readFile(path.join(TEST_DATA_DIR, 'test-page.md'), 'utf-8');
+      expect(content).toContain('# Test');
+    });
+
+    it('should require content parameter', async () => {
+      const result = await executeTool(
+        'create_page',
+        { path: 'test.md' },
+        { sessionId: 'test' }
+      );
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('Invalid input');
+    });
+  });
+
+  describe('get_page Tool', () => {
+    it('should retrieve page content', async () => {
+      // Create a page first
+      await testFileSystemService.createPage('readme.md', '# Hello World\n\nTest content');
+
+      const result = await executeTool(
+        'get_page',
+        { path: 'readme.md' },
+        { sessionId: 'test' }
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect((result.content[0] as { text: string }).text).toContain('Hello World');
+    });
+
+    it('should return error for non-existent page', async () => {
+      const result = await executeTool(
+        'get_page',
+        { path: 'non-existent.md' },
+        { sessionId: 'test' }
+      );
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('update_page Tool', () => {
+    it('should update existing page', async () => {
+      // Create a page first
+      await testFileSystemService.createPage('update-test.md', '# Original');
+
+      const result = await executeTool(
+        'update_page',
+        {
+          path: 'update-test.md',
+          content: '# Updated Content',
+        },
+        { sessionId: 'test' }
+      );
+
+      expect(result.isError).toBeFalsy();
+
+      // Verify content was updated
+      const content = await fs.readFile(path.join(TEST_DATA_DIR, 'update-test.md'), 'utf-8');
+      expect(content).toContain('Updated Content');
+    });
+  });
+
+  describe('search_pages Tool', () => {
+    it('should search for pages by query', async () => {
+      // Create some pages
+      await testFileSystemService.createPage('apple.md', '# Apple\n\nA delicious fruit');
+      await testFileSystemService.createPage('banana.md', '# Banana\n\nYellow fruit');
+
+      const result = await executeTool(
+        'search_pages',
+        { query: 'apple' },
+        { sessionId: 'test' }
+      );
+
+      expect(result.isError).toBeFalsy();
+
+      // Tool returns human-readable text
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Found');
+      expect(text).toContain('apple');
+    });
+
+    it('should return no matches message for no results', async () => {
+      const result = await executeTool(
+        'search_pages',
+        { query: 'xyz123nonexistent' },
+        { sessionId: 'test' }
+      );
+
+      expect(result.isError).toBeFalsy();
+
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('No matches found');
+    });
+  });
+
+  describe('delete_page Tool', () => {
+    it('should delete an existing page', async () => {
+      // Create a page first
+      await testFileSystemService.createPage('to-delete.md', '# Delete me');
+
+      const result = await executeTool(
+        'delete_page',
+        { path: 'to-delete.md' },
+        { sessionId: 'test' }
+      );
+
+      expect(result.isError).toBeFalsy();
+
+      // Verify page is deleted
+      await expect(
+        fs.access(path.join(TEST_DATA_DIR, 'to-delete.md'))
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('rename_folder Tool', () => {
+    it('should rename an existing folder', async () => {
+      // Create a folder first
+      await testFileSystemService.createFolder('old-name');
+
+      const result = await executeTool(
+        'rename_folder',
+        { oldPath: 'old-name', newPath: 'new-name' },
+        { sessionId: 'test' }
+      );
+
+      expect(result.isError).toBeFalsy();
+
+      // Verify folder was renamed
+      const stats = await fs.stat(path.join(TEST_DATA_DIR, 'new-name'));
+      expect(stats.isDirectory()).toBe(true);
+
+      // Old folder should not exist
+      await expect(
+        fs.access(path.join(TEST_DATA_DIR, 'old-name'))
+      ).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
- Add MCP server on port 3002 with Streamable HTTP transport
- Implement 12 tools for page/folder CRUD operations
- Add API key authentication and session management
- Create comprehensive test suite (45 tests)
- Update .env.example with MCP configuration
- Document setup in README and server/src/mcp/README.md

Dependencies: @modelcontextprotocol/sdk, zod