### PR TITLE
Upgrade @modelcontextprotocol/sdk and fast-xml-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15875,7 +15875,7 @@
       "name": "codex-server",
       "version": "1.0.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.3",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "cors": "^2.8.6",
         "express": "^4.18.2",
         "multer": "^2.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.3",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "cors": "^2.8.6",
     "express": "^4.18.2",
     "multer": "^2.0.2",


### PR DESCRIPTION
Update the @modelcontextprotocol/sdk dependency to version 1.26.0 and fast-xml-parser to version 5.3.4 to incorporate the latest features and improvements. Adjust other related dependencies accordingly.