### PR TITLE
Add Docker package ecosystem updates configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,18 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+
+  # Docker - keep base images up to date
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "09:00"
+    labels:
+      - "dependencies"
+      - "docker"
+      - "automated"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
Introduce a configuration for Dependabot to keep Docker base images up to date on a weekly schedule.