### PR TITLE
Update Node.js version in CI workflows to 25.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '24.x'
+        node-version: '25.x'
         cache: 'npm'
 
     - name: Install dependencies
@@ -53,7 +53,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '24.x'
+        node-version: '25.x'
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '25'
           cache: 'npm'
 
       - name: Configure Git


### PR DESCRIPTION
Bump the Node.js version from 24.x to 25.x in the CI workflows to ensure compatibility with the latest features and improvements.