### PR TITLE
feat(api): add endpoints for templates, search, and version history

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,45 @@
+# EditorConfig is awesome: http://EditorConfig.org
+# Uses editorconfig to maintain consistent coding styles
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_size = 2
+indent_style = space
+max_line_length = 0
+
+[*.json]
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+max_line_length = 0
+
+[package.json]
+; The various tools (npm, yarn, ...) that edit package.json files all
+; seem to use 2-space indent, not 4.
+indent_size = 2
+
+[Dockerfile]
+max_line_length = 0
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = true
+
+[Makefile]
+tab_width = 2
+indent_style = tab
+
+[COMMIT_EDITMSG]
+max_line_length = 0

--- a/client/src/components/Preview.test.tsx
+++ b/client/src/components/Preview.test.tsx
@@ -75,11 +75,7 @@ describe("Preview", () => {
       svg: '<svg data-testid="mmd"><g><text>OK</text></g></svg>',
       bindFunctions: undefined,
       diagramType: "flowchart",
-    } as unknown as {
-      svg: string;
-      bindFunctions?: (element: Element) => void;
-      diagramType: string;
-    });
+    } as unknown as { svg: string; bindFunctions?: (element: Element) => void; diagramType: string });
 
     document.documentElement.setAttribute("data-theme", "dark");
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -132,6 +132,18 @@ app.get("/api", (req: Request, res: Response) => {
           description: "Get page content",
           example: `curl ${baseUrl}/api/pages/My%20Folder/page.md`,
         },
+        "GET /api/pages/:path/history": {
+          description: "Get Git-backed version history for a page",
+          example: `curl ${baseUrl}/api/pages/My%20Folder/page.md/history`,
+        },
+        "GET /api/pages/:path/versions/:hash": {
+          description: "Get a specific historical version of a page",
+          example: `curl ${baseUrl}/api/pages/My%20Folder/page.md/versions/<commit-hash>`,
+        },
+        "POST /api/pages/:path/restore/:hash": {
+          description: "Restore a page to a specific historical version",
+          example: `curl -X POST ${baseUrl}/api/pages/My%20Folder/page.md/restore/<commit-hash>`,
+        },
         "POST /api/pages": {
           description: "Create a new page",
           body: { path: "folder/page.md", content: "markdown content" },
@@ -156,6 +168,22 @@ app.get("/api", (req: Request, res: Response) => {
           body: { oldPath: "folder1/page.md", newFolderPath: "folder2" },
           returns: { success: true, newPath: "folder2/page.md" },
           example: `curl -X PUT ${baseUrl}/api/pages/move -H "Content-Type: application/json" -d '{"oldPath": "folder1/page.md", "newFolderPath": "folder2"}'`,
+        },
+      },
+      templates: {
+        "GET /api/templates": {
+          description: "List available page templates (from the data/templates folder)",
+          returns: "Array of templates with path, template name, autoname, and content",
+          example: `curl ${baseUrl}/api/templates`,
+        },
+      },
+      search: {
+        "GET /api/search": {
+          description: "Full-text search across all pages",
+          query: { q: "search term" },
+          returns:
+            "Array of results with path, title, snippet (HTML), and match count",
+          example: `curl "${baseUrl}/api/search?q=terraform"`,
         },
       },
       auth: {

--- a/server/tests/api.test.ts
+++ b/server/tests/api.test.ts
@@ -236,6 +236,28 @@ describe('API Tests', () => {
     });
   });
 
+  describe('API Documentation', () => {
+    it('should include templates, search, and version history endpoints', async () => {
+      const response = await request(app).get('/api');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('endpoints');
+
+      expect(response.body.endpoints).toHaveProperty('templates');
+      expect(response.body.endpoints).toHaveProperty('search');
+
+      expect(response.body.endpoints.pages).toHaveProperty(
+        'GET /api/pages/:path/history',
+      );
+      expect(response.body.endpoints.pages).toHaveProperty(
+        'GET /api/pages/:path/versions/:hash',
+      );
+      expect(response.body.endpoints.pages).toHaveProperty(
+        'POST /api/pages/:path/restore/:hash',
+      );
+    });
+  });
+
   describe('Version History', () => {
     it('should track page creation and updates in Git', async () => {
       // Create a page


### PR DESCRIPTION
I'm mostly just updating the API documentation - but also slipping in a .editorconfig file too