### PR TITLE
Include default templates for first-run seeding in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ dist/
 .github/
 *.md
 !README.md
+!data/templates/**
 .env*
 .DS_Store
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,9 @@ RUN npm ci --omit=dev
 COPY --from=builder /app/server/dist ./server/dist
 COPY --from=builder /app/client/dist ./client/dist
 
+# Include default templates in the image for first-run seeding into the mounted data volume
+COPY data/templates ./seed/templates
+
 # Create data directory and set permissions
 RUN mkdir -p /app/data && chown -R codex:codex /app
 
@@ -55,6 +58,11 @@ EXPOSE 3001
 # Set environment variables
 ENV NODE_ENV=production
 ENV PORT=3001
+ENV DATA_DIR=/app/data
+
+# Seed templates into the data volume on first run (only if data/templates is missing or empty)
+ENV CODEX_SEED_TEMPLATES=true
+ENV CODEX_SEED_TEMPLATES_DIR=/app/seed/templates
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/README.md
+++ b/README.md
@@ -550,6 +550,9 @@ docker stop codex && docker rm codex
 **Volume Mounting**:
 - `./data:/app/data` - Persists your wiki data outside the container
 
+**Templates on first run**:
+- The Docker image includes built-in starter templates; on first startup, if `data/templates/` is missing or empty, Codex will copy the defaults into it.
+
 ### Authentication in Docker
 
 **Important**: Due to secure cookie requirements, there are two ways to run Codex with authentication:


### PR DESCRIPTION
Add built-in starter templates to the Docker image, enabling automatic seeding into the data volume on first startup if the templates directory is missing or empty. Update documentation to reflect this feature.